### PR TITLE
feat: add Module Navbar display and enhance section naming in backgro…

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -27,7 +27,7 @@ const displayScripts = [
     id: "displaySectionColumns",
     file: "content/displays/SectionColumn/displaySectionColumns.js",
     matches: ["https://*.instructure.com/accounts/*"],
-    name: "Display Sections Column",
+    name: "Sections Column",
     description: "Adds a dedicated 'Sections' column to the course listings on Canvas. Get a quick, at-a-glance summary of each course's section details.",
     runAt: "document_idle"
   },
@@ -35,8 +35,16 @@ const displayScripts = [
     id: "displaySectionsBreadcrumb",
     file: "content/displays/SectionsBreadcrumb/displaySectionsBreadcrumb.js",
     matches: ["https://*.instructure.com/courses/*"],
-    name: "Display Sections in Breadcrumbs",
+    name: "Sections in Breadcrumbs",
     description: "Enhances the breadcrumb trail by appending formatted section numbers for the current course.",
+    runAt: "document_idle"
+  },
+  {
+    id: "displayModuleNavbar",
+    file: "content/displays/ModuleNavbar/displayModuleNavbar.js",
+    matches: ["https://*.instructure.com/*/modules"],
+    name: "Module Navbar",
+    description: "Displays a navbar on the modules page of a course.",
     runAt: "document_idle"
   }
   // Add additional display scripts as needed

--- a/content/displays/ModuleNavbar/displayModuleNavbar.js
+++ b/content/displays/ModuleNavbar/displayModuleNavbar.js
@@ -1,0 +1,66 @@
+"use strict";
+
+/**
+ * Retrieves module anchor tags from the page, filtering out any that don't have a valid ID.
+ * @returns {HTMLElement[]} An array of module anchor elements.
+ */
+const getModules = () => {
+  return Array.from(document.querySelectorAll('[data-module-id] > a[id*="module_"]'))
+    .filter(anchor => anchor.id !== 'module_');
+};
+
+/**
+ * Creates a navigation bar element for modules if it doesn't already exist.
+ */
+const createNavbar = () => {
+  const sidebar = document.querySelector('#header');
+  if (!sidebar) return;
+  const sidebarWidth = window.getComputedStyle(sidebar).getPropertyValue('width');
+  const navbar = document.createElement('div');
+  navbar.id = 'navToModule_ext';
+  Object.assign(navbar.style, {
+    height: '24px',
+    lineHeight: '24px',
+    width: `calc(100vw - ${sidebarWidth})`,
+    maxWidth: `calc(100vw - ${sidebarWidth})`,
+    zIndex: '10',
+    backgroundColor: 'white',
+    borderTop: '1px solid #ddd',
+    padding: '2px',
+    color: 'black',
+    position: 'fixed',
+    bottom: '0',
+    left: sidebarWidth,
+    display: 'flex'
+  });
+  document.body.appendChild(navbar);
+};
+
+/**
+ * Populates the navigation bar with links derived from the modules.
+ * Each link's title is based on a nearby header element.
+ * @param {HTMLElement[]} modules - An array of module anchor elements.
+ */
+const fillNavbar = (modules) => {
+  const navbar = document.querySelector('#navToModule_ext');
+  if (!navbar) return;
+  navbar.innerHTML = modules.reduce((acc, module) => {
+    const headerEl = document.querySelector(`#${module.id} + div > h2`);
+    if (!headerEl) return acc;
+    let title = headerEl.innerHTML;
+    const match = title.match(/(lesson|week|w|l)\s*(\d\d?)/i);
+    if (match) {
+      const digits = match[2];
+      title = digits.length === 1 ? `W0${digits}` : `W${digits}`;
+    }
+    return acc + `<a href="#${module.id}" id="${title}" style="font-size: 14px; padding: 0 7px;">${title}</a>`;
+  }, '');
+};
+
+// Check if the navToModules option is enabled and then create and populate the navbar.
+
+if (!document.querySelector('#navToModule_ext')) {
+    createNavbar();
+}
+
+fillNavbar(getModules());

--- a/content/displays/ModuleNavbar/moduleNavbar.md
+++ b/content/displays/ModuleNavbar/moduleNavbar.md
@@ -1,0 +1,57 @@
+# displayModulesNavbar.js
+
+## Overview
+
+The `displayModulesNavbar.js` script is a display function for the BYUI Canvas Admin Tools extension. Its purpose is to create a dynamic navigation bar at the bottom of the page that allows quick access to various course modules. The script collects module links from the page, generates a responsive navbar based on the width of the sidebar, and populates the navbar with links whose titles are derived from nearby header elements.
+
+## Features
+
+- **Module Retrieval:**  
+  Uses modern DOM APIs to collect anchor tags that represent course modules, filtering out any invalid entries.
+
+- **Dynamic Navbar Creation:**  
+  Calculates the sidebar width and creates a fixed navigation bar that spans the remaining viewport width. This ensures a responsive layout.
+
+- **Dynamic Link Population:**  
+  For each module, the script locates a nearby header element to derive the link title. It applies formatting rules to abbreviate titles (e.g., converting lesson/week identifiers to a standardized format).
+
+- **Conditional Execution:**  
+  The script only runs if the user has enabled the `navToModules` option in chrome.storage.
+
+## How It Works
+
+1. **getModules():**  
+   Collects all module anchor tags from elements with a `data-module-id` attribute, filtering out any anchors with an invalid ID.
+
+2. **createNavbar():**  
+   - Retrieves the computed width of the sidebar (`#header`).
+   - Creates a new `<div>` element styled as a navigation bar.
+   - Sets the navbar’s width to the remaining viewport width and positions it fixed at the bottom.
+   - Appends the navbar to the `<body>`.
+
+3. **fillNavbar(modules):**  
+   - Iterates over the module anchors.
+   - For each module, it locates an adjacent header element (using a CSS sibling selector) to extract the module title.
+   - Applies regex-based formatting to abbreviate titles (e.g., converting "Week 2" to "W02").
+   - Generates a series of `<a>` elements that link to the module, appending them into the navbar.
+
+4. **Integration with Extension Settings:**  
+   - Uses `chrome.storage.sync.get()` to check if the `navToModules` option is enabled.
+   - If enabled, the script creates the navbar (if not already present) and populates it with module links.
+
+
+## Customization
+
+- **Styling:**  
+  The navbar's styling is defined inline via JavaScript. You can modify the styles in the `Object.assign()` call within `createNavbar()` to suit your design needs.
+  
+- **Link Title Formatting:**  
+  The regex in `fillNavbar()` can be adjusted to match different module naming conventions if needed.
+
+## Troubleshooting
+
+- **Navbar Not Appearing:**  
+  Ensure that the `navToModules` option is enabled in chrome.storage and that the page contains elements matching the selectors used in `getModules()` and `createNavbar()`.
+  
+- **Incorrect Titles:**  
+  Verify that the adjacent header elements are correctly selected. Adjust the CSS selector in `fillNavbar()` if your page structure differs.


### PR DESCRIPTION
This pull request introduces a new feature to the `background/background.js` script and adds a new script for displaying a navigation bar on the modules page in Canvas. The changes include updates to the display scripts configuration, the implementation of the new `displayModuleNavbar.js` script, and documentation for the new feature.

### New Feature: Module Navigation Bar

* **Configuration Updates:**
  - Updated the names of existing display scripts for consistency (`Sections Column`, `Sections in Breadcrumbs`).
  - Added a new entry for the `Module Navbar` script in the `displayScripts` array.

* **Implementation of `displayModuleNavbar.js`:**
  - Added a script to create a dynamic navigation bar at the bottom of the modules page, which includes:
    - Retrieving module anchor tags from the page.
    - Creating a navigation bar element and appending it to the document body.
    - Populating the navigation bar with links derived from module headers.

* **Documentation for `displayModuleNavbar.js`:**
  - Created a markdown file `moduleNavbar.md` to provide an overview, features, functionality, customization options, and troubleshooting tips for the new script.…und scripts and documentation