### PR TITLE
Feat/display section parent link

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -51,8 +51,8 @@ const displayScripts = [
     id: "displayParentLink",
     file: "content/displays/ParentLink/displayParentLink.js",
     matches: ["https://*.instructure.com/courses/*"],
-    name: "Module Navbar",
-    description: "Displays a navbar on the modules page of a course.",
+    name: "Blueprint Parent Link",
+    description: "Adds link in the bottom of the page to a course to its blueprint if it is a blueprint child.",
     runAt: "document_idle"
   }
   // Add additional display scripts as needed

--- a/background/background.js
+++ b/background/background.js
@@ -46,6 +46,14 @@ const displayScripts = [
     name: "Module Navbar",
     description: "Displays a navbar on the modules page of a course.",
     runAt: "document_idle"
+  },
+  {
+    id: "displayParentLink",
+    file: "content/displays/ParentLink/displayParentLink.js",
+    matches: ["https://*.instructure.com/courses/*"],
+    name: "Module Navbar",
+    description: "Displays a navbar on the modules page of a course.",
+    runAt: "document_idle"
   }
   // Add additional display scripts as needed
 ];

--- a/content/displays/ParentLink/ParentLink.md
+++ b/content/displays/ParentLink/ParentLink.md
@@ -1,0 +1,63 @@
+# displayParentLink.js
+
+## Overview
+
+The `displayParentLink.js` script is a display function designed to enhance the BYUI Canvas Admin Tools extension. Its primary purpose is to fetch blueprint subscription data for the current course from the Canvas LMS API and, if blueprint data is available, create a navigation bar (if it doesn’t already exist) and append a link to the parent blueprint course. This link appears fixed at the bottom of the page and opens in a new tab.
+
+## Features
+
+- **Dynamic Navbar Creation:**  
+  Creates a responsive navbar at the bottom of the page based on the width of the sidebar (`#header`).
+
+- **Data Fetching with Modern APIs:**  
+  Uses async/await with the Fetch API to retrieve blueprint subscription data, removing extraneous prefixes before parsing.
+
+- **Conditional Link Injection:**  
+  If blueprint subscription data is present, the script appends a "Parent Blueprint" link to the navbar. The link’s destination is derived from the fetched data.
+
+
+## How It Works
+
+1. **Navbar Creation (`createNavbar`):**  
+   - The function retrieves the computed width of the sidebar (`#header`) and creates a `<div>` element styled as a navbar.
+   - The navbar is fixed at the bottom of the page, spans the remaining viewport width, and is appended to the `<body>`.
+
+2. **Data Fetching (`buildDetails`):**  
+   - Extracts the course ID from the current URL.
+   - Uses the Fetch API to send a GET request to the Canvas LMS API endpoint for blueprint subscriptions.
+   - Cleans the response by removing the `"while(1);"` prefix and parses the JSON data.
+
+3. **Blueprint Link Injection (`addBlueprintParent`):**  
+   - Calls `buildDetails` to obtain blueprint data.
+   - If data exists, it ensures that the navbar is present by calling `createNavbar` if necessary.
+   - Extracts the blueprint course ID from the data and creates an `<a>` element with the text "Parent Blueprint."
+   - The link is styled and appended to the navbar; it opens in a new tab.
+
+4. **Option Check:**  
+   - The script checks the `addBlueprintParent` option stored in `chrome.storage.sync`.
+   - If the option is enabled (`true`), `addBlueprintParent()` is executed.
+
+## Integration
+
+- **Usage:**  
+  Include `displayParentLink.js` as a display content script in your extension. Ensure that your manifest grants the necessary permissions and that your Canvas LMS pages match the required URL patterns.
+
+- **Configuration:**  
+  The script is activated based on the `addBlueprintParent` setting in `chrome.storage.sync`. Adjust this setting via your extension's options page to enable or disable the blueprint parent link feature.
+
+## Customization
+
+- **Styling:**  
+  The navbar and link styles are set using inline styles via `Object.assign()`. Modify these values to suit your design requirements.
+  
+- **Data Endpoint:**  
+  The API endpoint URL is hard-coded; update it if your Canvas LMS domain changes.
+
+## Troubleshooting
+
+- **Navbar Not Appearing:**  
+  Ensure that the page contains a sidebar element with the ID `#header`, as the navbar’s position and width are based on this element.
+  
+- **Data Fetch Errors:**  
+  Check the console for errors related to fetching data. Ensure the API endpoint is correct and that the response format is as expected.
+  

--- a/content/displays/ParentLink/displayParentLink.js
+++ b/content/displays/ParentLink/displayParentLink.js
@@ -1,0 +1,85 @@
+"use strict";
+
+/**
+ * Creates a navigation bar at the bottom of the page if it doesn't already exist.
+ * The navbar is positioned based on the computed width of the sidebar (#header).
+ */
+function createParentNavbar() {
+  const sidebar = document.querySelector('#header');
+  if (!sidebar) return;
+  const sidebarWidth = window.getComputedStyle(sidebar).getPropertyValue('width');
+  
+  const navbar = document.createElement('div');
+  navbar.id = 'navToModule_ext';
+  Object.assign(navbar.style, {
+    height: '24px',
+    lineHeight: '24px',
+    width: `calc(100vw - ${sidebarWidth})`,
+    maxWidth: `calc(100vw - ${sidebarWidth})`,
+    zIndex: '10',
+    backgroundColor: 'white',
+    borderTop: '1px solid #ddd',
+    padding: '2px',
+    color: 'black',
+    position: 'fixed',
+    bottom: '0',
+    left: sidebarWidth,
+    display: 'flex'
+  });
+  
+  document.body.appendChild(navbar);
+}
+
+/**
+ * Fetches blueprint subscription data for the current course using the Fetch API.
+ * Removes any extraneous prefixes from the response before parsing.
+ * @returns {Promise<Object[]>} - A promise that resolves with an array of blueprint subscriptions.
+ */
+async function buildDetails() {
+  const courseID = new URL(document.location.href).pathname.split('/')[2];
+  try {
+    const host = window.location.origin;
+    const response = await fetch(`${host}/api/v1/courses/${courseID}/blueprint_subscriptions`);
+    const responseJSON = await response.json();
+    return responseJSON;
+  } catch (err) {
+    throw new Error(`Failure to retrieve data for course ${courseID}: ${err}`);
+  }
+}
+
+/**
+ * Fetches blueprint subscription data and, if available, creates or updates
+ * the navbar with a link to the parent blueprint course.
+ */
+async function addBlueprintParent() {
+  try {
+    const blueprintData = await buildDetails();
+    const host = window.location.origin;
+    if (Object.keys(blueprintData).length > 0) {
+      if (!document.getElementById('navToModule_ext')) {
+        createNavbar();
+      }
+      const blueprintID = blueprintData[0].blueprint_course.id;
+      const navbar = document.getElementById('navToModule_ext');
+      // Create an anchor element for the parent blueprint link
+      const anchor = document.createElement('a');
+      anchor.href = `${host}/courses/${blueprintID}`;
+      anchor.id = 'parentBlueprintCourse';
+      anchor.target = '_blank';
+      Object.assign(anchor.style, {
+        fontSize: '14px',
+        padding: '0 7px',
+        position: 'fixed',
+        right: '0'
+      });
+      anchor.textContent = 'Parent Blueprint';
+      navbar.appendChild(anchor);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+// Check if the option to add the blueprint parent link is enabled
+addBlueprintParent();
+

--- a/content/displays/SectionsBreadcrumb/displaySectionsBreadcrumb.js
+++ b/content/displays/SectionsBreadcrumb/displaySectionsBreadcrumb.js
@@ -11,8 +11,6 @@ async function getData(courseID) {
     const host = window.location.origin;
     const response = await fetch(`${host}/api/v1/courses/${courseID}/sections`);
     const jsonReponse = await response.json();
-    console.log("BREADCRUMBS")
-    console.log(jsonReponse)
 
     return jsonReponse;
 }


### PR DESCRIPTION
This pull request introduces a new display script for adding a blueprint parent link to the Canvas LMS and includes documentation and implementation for this feature. Additionally, it removes unnecessary console logs from another display script.

### New Feature Implementation:

* **New display script added**: The `displayParentLink.js` script has been added to the list of display scripts in `background/background.js`. This script adds a link to the parent blueprint course if the current course is a blueprint child.
* **Blueprint parent link script**: The new `displayParentLink.js` script includes functions to create a navigation bar, fetch blueprint subscription data, and append a link to the parent blueprint course.

### Documentation:

* **Documentation for blueprint parent link**: A new markdown file, `ParentLink.md`, has been added to provide an overview, features, integration steps, customization options, and troubleshooting tips for the `displayParentLink.js` script.

### Code Cleanup:

* **Removed console logs**: Unnecessary console logs have been removed from the `getData` function in `displaySectionsBreadcrumb.js`.