### PR TITLE
feat: add display for associated sections in blueprint courses

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -54,6 +54,14 @@ const displayScripts = [
     name: "Blueprint Parent Link",
     description: "Adds link in the bottom of the page to a course to its blueprint if it is a blueprint child.",
     runAt: "document_idle"
+  },
+  {
+    id: "displayBlueprintSections",
+    file: "content/displays/BlueprintSections/displayBlueprintSections.js",
+    matches: ["https://*.instructure.com/courses/*"],
+    name: "Blueprint Associated Sections",
+    description: `Adds a link to the sections associated with a blueprint course when in "Associated Courses".`,
+    runAt: "document_idle"
   }
   // Add additional display scripts as needed
 ];

--- a/content/displays/BlueprintSections/displayBlueprintSections.js
+++ b/content/displays/BlueprintSections/displayBlueprintSections.js
@@ -1,0 +1,55 @@
+// displayParentLink.js
+"use strict";
+
+/**
+ * Enhances blueprint association links by ensuring that each module row
+ * in the blueprint associations table includes a clickable link to the course.
+ */
+const blueprintAssociations = () => {
+  const associatedCourses = document.querySelectorAll(
+    'span[dir="ltr"] .bca-associations-table tr[id^="course_"]'
+  );
+  associatedCourses.forEach(row => {
+    const courseID = row.id.split('_')[1];
+    const linkSpan = row.querySelector('td span');
+    if (!linkSpan) return;
+    const currentHTML = linkSpan.innerHTML;
+    const expectedLinkHTML = `<a href="/courses/${courseID}" target="_blank">${currentHTML}</a>`;
+    if (!currentHTML.includes(expectedLinkHTML)) {
+      linkSpan.innerHTML = expectedLinkHTML;
+    }
+  });
+};
+
+/**
+ * Sets up a debounced MutationObserver on the given parent element.
+ * The callback (blueprintAssociations) is invoked after changes are detected,
+ * debounced by the specified delay.
+ * @param {HTMLElement} parent - The element to observe.
+ * @param {number} delay - Debounce delay in milliseconds.
+ */
+function observeChanges(parent, delay = 250) {
+  let timeoutId;
+  const observer = new MutationObserver(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      blueprintAssociations();
+    }, delay);
+  });
+  observer.observe(parent, { childList: true, subtree: true });
+  return observer;
+}
+
+// Always run the blueprintAssociations function immediately if the target elements exist.
+const runImmediately = () => {
+  const targets = document.querySelectorAll('span[dir="ltr"] .bca-associations-table tr[id^="course_"] span');
+  if (targets.length > 0) {
+    blueprintAssociations();
+  }
+};
+
+
+// Run immediately to ensure links are displayed when the page is opened.
+runImmediately();
+// Set up an observer on the entire document to capture future changes.
+observeChanges(document, 250);


### PR DESCRIPTION
This pull request adds a new display script to enhance blueprint association links in a course management system. The most important changes include adding a new script to the list of display scripts and implementing the functionality to ensure each module row in the blueprint associations table includes a clickable link to the course.

Enhancements to blueprint association links:

* [`background/background.js`](diffhunk://#diff-c09a234d34a31a681bbf56b6a0170b2b9423138e4b34a7cee76e038ba2f5062fR57-R64): Added a new display script `displayBlueprintSections` to the list of display scripts. This script matches URLs for courses and runs at document idle time.

Implementation of the new display script:

* [`content/displays/BlueprintSections/displayBlueprintSections.js`](diffhunk://#diff-b0514b9c495749d04b0342b96ef2c00602d0db61709d4bc8b9cfaec4866bba3fR1-R55): Implemented the `blueprintAssociations` function to add clickable links to each module row in the blueprint associations table. Set up a debounced `MutationObserver` to observe changes and run the function immediately if the target elements exist.