### PR TITLE
Feat/manage blueprint lock

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -13,10 +13,10 @@ const clickableScripts = [
     file: "content/clickables/DeleteAllQuestions/deleteAllQuestions.js" 
   },
   { 
-    id: "clickableScript2", 
-    name: "Action Two", 
-    description:"Description of Action 2", 
-    file: "content/clickables/clickableScript2.js" 
+    id: "blueprintLock", 
+    name: "Lock Blueprint Items", 
+    description:"Locks every blueprint item present in the page. Only works in a list of items where the lock button is present (modules, assignments, quizzes, etc).", 
+    file: "content/clickables/BlueprintLock/blueprintLock.js" 
   }
   // Add more clickable scripts as needed
 ];

--- a/content/clickables/BlueprintLock/BlueprintLock.md
+++ b/content/clickables/BlueprintLock/BlueprintLock.md
@@ -1,0 +1,27 @@
+# blueprintLock.js
+
+## Overview
+
+The `blueprintLock.js` script is a clickable content script for the BYUI Canvas Admin Tools extension. Its purpose is to lock every blueprint item present on a page—such as those found in modules, assignments, quizzes, etc.—by simulating clicks on all elements that are currently unlocked. This script is intended to be triggered by a user action (e.g., clicking a button in the popup) and is part of the master list under the ID `"blueprintLock"`.
+
+## Features
+
+- **Bulk Locking:**  
+  Automatically locates and clicks all elements with the classes `.lock-icon` and `.btn-unlocked` to lock blueprint items in one operation.
+
+- **Console Logging:**  
+  Logs key actions (starting the process, if no elements are found, and completion) to the console for debugging and confirmation purposes.
+
+## How It Works
+
+1. **Element Selection:**  
+   The script selects all elements on the page that match the CSS selector `.lock-icon.btn-unlocked`. These elements represent blueprint items that are currently unlocked.
+
+2. **Condition Check:**  
+   If no such elements are found, the script logs a message ("There is nothing to lock.") and exits.
+
+3. **Simulated Clicks:**  
+   For each unlocked blueprint element, the script simulates a click event, triggering the locking mechanism built into the page.
+
+4. **Logging:**  
+   The script logs "running" at the start and "Locked" after processing all elements, providing feedback on its operation.

--- a/content/clickables/BlueprintLock/blueprintLock.js
+++ b/content/clickables/BlueprintLock/blueprintLock.js
@@ -1,0 +1,14 @@
+function lockElements() {
+    console.log('running');
+    let elms = document.querySelectorAll('.lock-icon.btn-unlocked');
+    if (elms.length === 0) {
+        console.log('There is nothing to lock.');
+        return;
+    }
+    elms.forEach(el => {
+        el.click();
+    })
+    console.log('Locked');
+}
+
+lockElements();


### PR DESCRIPTION
This pull request introduces a new feature to the BYUI Canvas Admin Tools extension, specifically adding a script to lock blueprint items on a page. The most important changes include adding the new script to the list of clickable scripts, creating the script file, and documenting its functionality.

### New Feature: Blueprint Lock Script

* [`background/background.js`](diffhunk://#diff-c09a234d34a31a681bbf56b6a0170b2b9423138e4b34a7cee76e038ba2f5062fL16-R19): Replaced the `clickableScript2` entry with the new `blueprintLock` script entry, including its ID, name, description, and file path.
* [`content/clickables/BlueprintLock/blueprintLock.js`](diffhunk://#diff-8f5417894acae49a65d965f847d6b5ac9ca38d0179d0812c50fde06cfd90d356R1-R14): Added a new script that selects unlocked blueprint items on a page and simulates clicks to lock them, logging the process to the console.
* [`content/clickables/BlueprintLock/BlueprintLock.md`](diffhunk://#diff-d2abfdafee9cd3fd8beef71bcd138bca69a3eba7f3a7a762176d92a12b14eca0R1-R27): Created documentation for the `blueprintLock.js` script, detailing its purpose, features, and how it works.