### PR TITLE
Feat/manage blueprint unlock

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -17,6 +17,12 @@ const clickableScripts = [
     name: "Lock Blueprint Items", 
     description:"Locks every blueprint item present in the page. Only works in a list of items where the lock button is present (modules, assignments, quizzes, etc).", 
     file: "content/clickables/BlueprintLock/blueprintLock.js" 
+  },
+  { 
+    id: "blueprintUnlock", 
+    name: "Unlock Blueprint Items", 
+    description:"Unlocks every blueprint item present in the page. Only works in a list of items where the lock button is present (modules, assignments, quizzes, etc).", 
+    file: "content/clickables/BlueprintUnlock/blueprintUnlock.js" 
   }
   // Add more clickable scripts as needed
 ];

--- a/content/clickables/BlueprintUnlock/BlueprintUnlock.md
+++ b/content/clickables/BlueprintUnlock/BlueprintUnlock.md
@@ -1,0 +1,29 @@
+# blueprintUnlock.js
+
+## Overview
+
+The `blueprintUnlock.js` script is a clickable content script for the BYUI Canvas Admin Tools extension. Its purpose is to unlock every blueprint item present on the page—such as those found in modules, assignments, quizzes, etc.—by simulating clicks on all elements that are currently locked. This script is intended to be triggered by a user action (for example, from a popup button) and is part of the master list under the ID `"blueprintUnlock"`.
+
+## Features
+
+- **Bulk Unlocking:**  
+  The script automatically selects all elements on the page that match the CSS selector `.lock-icon.lock-icon-locked`, which represent blueprint items that are currently locked, and simulates a click on each to unlock them.
+
+- **Console Logging:**  
+  Logs key actions (start, if no items are found, and completion) to the console for debugging and confirmation purposes.
+
+## How It Works
+
+1. **Element Selection:**  
+   - The script selects all elements with the classes `.lock-icon` and `.lock-icon-locked` using `document.querySelectorAll`.
+   - These elements are assumed to represent blueprint items that are currently locked.
+
+2. **Condition Check:**  
+   - If no locked blueprint items are found, the script logs "There is nothing to unlock." and exits.
+
+3. **Simulated Clicks:**  
+   - For each locked blueprint element found, the script simulates a click event to unlock it.
+   - Once all locked items are processed, the script logs "Unlocked" to the console.
+
+4. **Execution:**  
+   - The script runs immediately when injected, so that it performs the unlocking action on demand.

--- a/content/clickables/BlueprintUnlock/blueprintUnlock.js
+++ b/content/clickables/BlueprintUnlock/blueprintUnlock.js
@@ -1,0 +1,14 @@
+function unlockElements() {
+    console.log('running');
+    let elms = document.querySelectorAll('.lock-icon.lock-icon-locked');
+    if (elms.length === 0) {
+        console.log('There is nothing to unlock.');
+        return;
+    }
+    elms.forEach(el => {
+        el.click();
+    })
+    console.log('Unlocked');
+}
+
+unlockElements();


### PR DESCRIPTION
This pull request introduces a new feature to the BYUI Canvas Admin Tools extension, specifically adding functionality to unlock blueprint items on a page. The key changes include the addition of a new script for unlocking items, updates to the list of clickable scripts, and detailed documentation for the new script.

### New Feature: Unlock Blueprint Items

* **New Script Addition**:
  * [`background/background.js`](diffhunk://#diff-c09a234d34a31a681bbf56b6a0170b2b9423138e4b34a7cee76e038ba2f5062fR20-R25): Added a new entry for the "Unlock Blueprint Items" script to the `clickableScripts` array.
  * [`content/clickables/BlueprintUnlock/blueprintUnlock.js`](diffhunk://#diff-64dd03e07f948847fbaa0b02ea80bca1270b7e88430a4a733c0e147a569a205eR1-R14): Implemented the `unlockElements` function to select locked blueprint items and simulate clicks to unlock them.

* **Documentation**:
  * [`content/clickables/BlueprintUnlock/BlueprintUnlock.md`](diffhunk://#diff-a5aad495b7ea44e9bc9f2034e3e6e0d647ed790ba7f891ec992c68c47ad2a6cfR1-R29): Added comprehensive documentation for the `blueprintUnlock.js` script, detailing its purpose, features, and how it works.