### PR TITLE
style: add new cog SVG and update styles for branding colors

### DIFF
--- a/assets/Cog-old.svg
+++ b/assets/Cog-old.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 144 144" style="enable-background:new 0 0 144 144;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#231F20;}
+</style>
+<title>Cog</title>
+<path class="st0" d="M129.3,57.7l-6.7-16.1l6-14.9l-11.4-11.3l-14.9,6l-16.1-6.7L80,0H64l-6.3,14.7l-16.1,6.7l-14.9-6L15.4,26.8
+	c2,5,4,9.9,6,14.9l-6.7,16.1L0,64v16l14.7,6.3l6.7,16.1l-6,14.9l11.3,11.3l14.9-6l16.1,6.7L64,144h16l6.3-14.7l16.1-6.7l14.9,6
+	l11.3-11.3c-2-5-4-9.9-6-14.9l6.7-16.1L144,80V64L129.3,57.7z M72,114.7c-23.6,0-42.7-19.1-42.7-42.7c0-11.8,4.8-22.5,12.5-30.2
+	S60.2,29.3,72,29.3c23.6,0,42.7,19.1,42.7,42.7S95.6,114.7,72,114.7z"/>
+</svg>

--- a/assets/Cog.svg
+++ b/assets/Cog.svg
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 144 144" style="enable-background:new 0 0 144 144;" xml:space="preserve">
-<style type="text/css">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144" width="144px" height="144px"><defs><style type="text/css">
 	.st0{fill:#231F20;}
-</style>
-<title>Cog</title>
-<path class="st0" d="M129.3,57.7l-6.7-16.1l6-14.9l-11.4-11.3l-14.9,6l-16.1-6.7L80,0H64l-6.3,14.7l-16.1,6.7l-14.9-6L15.4,26.8
-	c2,5,4,9.9,6,14.9l-6.7,16.1L0,64v16l14.7,6.3l6.7,16.1l-6,14.9l11.3,11.3l14.9-6l16.1,6.7L64,144h16l6.3-14.7l16.1-6.7l14.9,6
-	l11.3-11.3c-2-5-4-9.9-6-14.9l6.7-16.1L144,80V64L129.3,57.7z M72,114.7c-23.6,0-42.7-19.1-42.7-42.7c0-11.8,4.8-22.5,12.5-30.2
-	S60.2,29.3,72,29.3c23.6,0,42.7,19.1,42.7,42.7S95.6,114.7,72,114.7z"/>
-</svg>
+</style></defs><path class="st0" d="M129.3,57.7l-6.7-16.1l6-14.9l-11.4-11.3l-14.9,6l-16.1-6.7L80,0H64l-6.3,14.7l-16.1,6.7l-14.9-6L15.4,26.8 c2,5,4,9.9,6,14.9l-6.7,16.1L0,64v16l14.7,6.3l6.7,16.1l-6,14.9l11.3,11.3l14.9-6l16.1,6.7L64,144h16l6.3-14.7l16.1-6.7l14.9,6 l11.3-11.3c-2-5-4-9.9-6-14.9l6.7-16.1L144,80V64L129.3,57.7z M72,114.7c-23.6,0-42.7-19.1-42.7-42.7c0-11.8,4.8-22.5,12.5-30.2 S60.2,29.3,72,29.3c23.6,0,42.7,19.1,42.7,42.7S95.6,114.7,72,114.7z" style="fill: rgb(255, 255, 255);" id="object-0" transform="matrix(1, 0, 0, 1, 0, -3.552713678800501e-15)"/></svg>

--- a/options/options.css
+++ b/options/options.css
@@ -5,8 +5,8 @@
   Tweak these variables to match your brand preference.
 */
 :root {
-    --primary-color: #005ca9;       /* Blue brand color */
-    --text-color: #212529;          /* Dark text */
+    --primary-color: #006EB6;       /* Blue brand color */
+    --text-color: #000000;          /* Dark text */
     --muted-text-color: #6c757d;    /* Bootstrap’s default muted text */
     --body-bg: #fff;
     --font-family-base: "Open Sans", Arial, sans-serif;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -13,13 +13,14 @@
     font-family: "Open Sans", Arial, sans-serif;
   }
   
-  /* Navbar branding color (already done via "bg-primary" in HTML).
-     If you want a custom color, override .bg-primary here:
      
   .navbar.bg-primary {
-    background-color: #005ca9 !important;
+    background-color: #000000 !important;
   }
-  */
+  
+  #clickable-buttons-container .btn-primary {
+    background-color: #006EB6 !important;
+  }
   
   /* Hover spin effect for the cog icon */
   #settings-cog {
@@ -28,6 +29,7 @@
   #settings-cog:hover {
     transform: rotate(90deg); /* 1/4 turn */
   }
+  
   
   /* Optional: Style for each button to have consistent look (beyond .btn-outline-primary):
   .btn {


### PR DESCRIPTION
This pull request includes changes to the CSS files to update the brand's primary color and text color. The most important changes include modifying the primary color and text color variables in the `options/options.css` file and updating the navbar and button styles in the `popup/popup.css` file.

Color updates:

* [`options/options.css`](diffhunk://#diff-48efbe062c8278b6323567b4496db2a3fe41e533e117cdf977532af6c5b39bf9L8-R9): Changed `--primary-color` to `#006EB6` and `--text-color` to `#000000` to match the new brand colors.

Navbar and button style updates:

* [`popup/popup.css`](diffhunk://#diff-7b1f20aea12a234b109c92688ed242d2a7238fe93e6992b685a55071e0a541d3L16-L22): Updated `.navbar.bg-primary` to use `#000000` as the background color and added a new style for `#clickable-buttons-container .btn-primary` to use `#006EB6` as the background color.
* [`popup/popup.css`](diffhunk://#diff-7b1f20aea12a234b109c92688ed242d2a7238fe93e6992b685a55071e0a541d3R33): Added a blank line for better readability and consistency in the code structure.