### PR TITLE
fix(ParentLink): fixed function name for the BlueprintParent

### DIFF
--- a/content/displays/ParentLink/displayParentLink.js
+++ b/content/displays/ParentLink/displayParentLink.js
@@ -58,7 +58,7 @@ async function addBlueprintParent() {
     const host = window.location.origin;
     if (Object.keys(blueprintData).length > 0) {
       if (!document.getElementById('navToModule_ext')) {
-        createNavbar();
+        createParentNavbar();
       }
       const blueprintID = blueprintData[0].blueprint_course.id;
       const navbar = document.getElementById('navToModule_ext');


### PR DESCRIPTION
This pull request includes a change to the `content/displays/ParentLink/displayParentLink.js` file to improve the function that handles adding a blueprint parent. The most important change is the modification of the function call to create the appropriate navigation bar.

* [`content/displays/ParentLink/displayParentLink.js`](diffhunk://#diff-9d99eca8f28ef14ed741c09322e32dbff5bad18bfa154820cf68d77d7755afbbL61-R61): Changed the function call from `createNavbar()` to `createParentNavbar()` in the `addBlueprintParent` function to ensure the correct navigation bar is created.