### PR TITLE
fix: added window close on the click of a clickable function

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 console.log(`Injected ${script.name} into tab ${tab.id}`);
               });
             }
+            window.close(); // Close the popup
           });
           container.appendChild(btn);
         });
@@ -31,6 +32,6 @@ document.addEventListener('DOMContentLoaded', () => {
         chrome.tabs.create({
             url: chrome.runtime.getURL("options/options.html")
           });
+        window.close(); // Close the popup
       });
   });
-  


### PR DESCRIPTION
This pull request makes small changes to the `popup/popup.js` file to improve the user experience by automatically closing the popup after specific actions are performed.

* [`popup/popup.js`](diffhunk://#diff-2ce48ac6dbf8501b60a7bbeb4c05cbd8b5eead20f4566669b124ade52182387bR23): Added `window.close()` to close the popup after injecting scripts into a tab.
* [`popup/popup.js`](diffhunk://#diff-2ce48ac6dbf8501b60a7bbeb4c05cbd8b5eead20f4566669b124ade52182387bR35-L36): Added `window.close()` to close the popup after opening the options page in a new tab.