### PR TITLE
chore: update version to 2.3.1 and add changelog entry for popup beha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.3.1] - 2025-05-22
+### Added
+- Patch: fixed behavior for popup to close when a clickable function button is clicked.
+
 ## [2.3.0] - 2025-05-22
 ### Added
 - Added "Search In Course" functionality that opens a window to search through all the content in the course.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Canvas Admin Tools V2",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Adds extra functionalities to Canvas LMS for admins by dynamically managing display and clickable scripts.",
     "icons": {
       "16": "assets/icon16.png",


### PR DESCRIPTION
This pull request includes a minor version update for the `Canvas Admin Tools V2` extension, introducing a small patch to improve user experience.

### Version update and patch details:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Added a new entry for version `2.3.1`, describing a fix for the popup behavior to close when a clickable function button is clicked.
* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Updated the version number from `2.3.0` to `2.3.1` to reflect the patch release.