### PR TITLE
Feat/open in bulk

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -103,6 +103,14 @@ const displayScripts = [
     name: "Sort Navigation Button",
     description: `Adds a "Sort Navigation" button to the "Navigation" tab's disabled items in the course settings page in Canvas.`,
     runAt: "document_idle"
+  },
+  {
+    id: "bulkLinkOpener",
+    file: "content/displays/BulkLinkOpener/bulkLinkOpener.js",
+    matches: ["<all_urls>"],
+    name: "Bulk Link Opener",
+    description: `Enables users to hold the Z key and drag a selection box over links on a webpage to open them all in new tabs.`,
+    runAt: "document_idle"
   }
   // Add additional display scripts as needed
 ];
@@ -229,6 +237,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       height: 470,
       focused: true
     });
+  } else if (msg.action === "openLink") {    
+      chrome.tabs.create({ url: msg.url });
   }
 });
 

--- a/content/displays/BulkLinkOpener/bulkLinkOpener.js
+++ b/content/displays/BulkLinkOpener/bulkLinkOpener.js
@@ -1,0 +1,164 @@
+function bulkLinkOpener() {
+    let zPressed = false;
+    let isDrawing = false;
+    let startX, startY;
+    let boxEl = null;
+    let linkCounter = null;
+
+    // Create link counter element
+    function createLinkCounter() {
+        linkCounter = document.createElement('div');
+        linkCounter.id = 'bulk-link-counter';
+        linkCounter.style.cssText = `
+            position: fixed;
+            background-color: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: bold;
+            pointer-events: none;
+            z-index: 999999;
+            display: none;
+        `;
+        document.body.appendChild(linkCounter);
+    }
+    
+    // Create counter element right away
+    createLinkCounter();
+
+    // Function to get links within selection box
+    function getLinksInSelection() {
+        if (!boxEl) {
+            return [];
+        }
+        
+        const boxRect = boxEl.getBoundingClientRect();
+        const links = document.querySelectorAll('a[href]');
+        const selectedLinks = [];
+        
+        links.forEach(link => {
+            const linkRect = link.getBoundingClientRect();
+            
+            // Check if the link overlaps with the selection box
+            if (
+                linkRect.left < boxRect.right &&
+                linkRect.right > boxRect.left &&
+                linkRect.top < boxRect.bottom &&
+                linkRect.bottom > boxRect.top
+            ) {
+                selectedLinks.push(link);
+            }
+        });
+        
+        return selectedLinks;
+    }
+
+    // Handle key down - check for Z key
+    document.addEventListener('keydown', e => {
+        if (e.key.toLowerCase() === 'z') {
+            zPressed = true;
+        }
+    });
+
+    // Handle key up - check for Z key release
+    document.addEventListener('keyup', e => {
+        if (e.key.toLowerCase() === 'z') {
+            zPressed = false;
+            if (boxEl) {
+                boxEl.remove();
+                boxEl = null;
+            }
+            
+            if (linkCounter) {
+                linkCounter.style.display = 'none';
+            }
+        }
+    });
+
+    // Handle mouse down - start drawing selection box
+    document.addEventListener('mousedown', e => {
+        if (!zPressed) return;
+        isDrawing = true;
+        startX = e.pageX;
+        startY = e.pageY;
+        
+        // Create box element
+        boxEl = document.createElement('div');
+        boxEl.style.cssText = `
+            position: absolute;
+            border: 2px dashed blue;
+            background-color: rgba(0, 0, 255, 0.1);
+            z-index: 999998;
+            pointer-events: none;
+        `;
+        document.body.appendChild(boxEl);
+        
+        // Initialize counter near mouse cursor
+        if (linkCounter) {
+            linkCounter.textContent = '0 links';
+            linkCounter.style.display = 'block';
+            linkCounter.style.left = (e.pageX - 50) + 'px';
+            linkCounter.style.top = (e.pageY + 20) + 'px';
+        }
+        
+        e.preventDefault();
+    });
+
+    // Handle mouse move - update selection box
+    document.addEventListener('mousemove', e => {
+        if (!isDrawing) return;  // Fixed missing return statement
+        
+        const width = Math.abs(e.pageX - startX);
+        const height = Math.abs(e.pageY - startY);
+        
+        let left = Math.min(startX, e.pageX);
+        let top = Math.min(startY, e.pageY);
+        
+        boxEl.style.left = left + 'px';
+        boxEl.style.top = top + 'px';
+        boxEl.style.width = width + 'px';
+        boxEl.style.height = height + 'px';
+        
+        // Update counter content
+        const selectedLinks = getLinksInSelection();
+        const linkCount = selectedLinks.length;
+        
+        if (linkCounter) {
+            linkCounter.textContent = `${linkCount} link${linkCount !== 1 ? 's' : ''}`;
+            linkCounter.style.left = (e.pageX - 50) + 'px';
+            linkCounter.style.top = (e.pageY + 20) + 'px';
+        }
+        
+        e.preventDefault();
+    });
+
+    // Handle mouse up - process selected links
+    document.addEventListener('mouseup', e => {
+        if (!isDrawing) return;  // Fixed missing return statement
+        isDrawing = false;
+        
+        // Get selected links
+        const selectedLinks = getLinksInSelection();
+        
+        if (boxEl) {
+            boxEl.remove();
+            boxEl = null;
+        }
+        
+        // Open each selected link in a new tab
+        selectedLinks.forEach(link => {
+            window.open(link.href, '_blank');
+        });
+        
+        // Hide the counter
+        if (linkCounter) {
+            linkCounter.style.display = 'none';
+        }
+        
+        e.preventDefault();
+    });
+}
+
+bulkLinkOpener();
+

--- a/manifest.json
+++ b/manifest.json
@@ -20,12 +20,13 @@
       "open_in_tab": true
     },
     "permissions": [
+      "tabs",
       "storage",
       "scripting",
       "activeTab",
       "windows"
     ],
     "host_permissions": [
-      "https://byui.instructure.com/*"
+      "<all_urls>"
     ]
   }


### PR DESCRIPTION
This pull request introduces a new feature called "Bulk Link Opener," which allows users to open multiple links on a webpage simultaneously by holding the Z key and dragging a selection box over the desired links. The changes include updates to the background script, the addition of a new content script, and modifications to the extension's permissions in the `manifest.json` file.

### Feature Implementation: Bulk Link Opener

* **New Script Added**: Added the `BulkLinkOpener` script to `displayScripts` in `background/background.js`, enabling the feature to be loaded and executed on all URLs.
* **Bulk Link Opener Functionality**: Implemented the `bulkLinkOpener` function in `content/displays/BulkLinkOpener/bulkLinkOpener.js`. This includes the ability to draw a selection box, count selected links, display notifications, and open links in new tabs.

### Background Script Updates

* **Message Listener Update**: Added support for the `openLink` action in `background/background.js` to open links in new tabs when triggered by the Bulk Link Opener feature.

### Permissions Updates

* **Manifest Permissions**: Updated `manifest.json` to include the `tabs` permission and expanded `host_permissions` to `<all_urls>` to allow the Bulk Link Opener feature to operate across all websites.