### PR TITLE
Feat/search in syllabus

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
       "open_in_tab": true
     },
     "permissions": [
-      "tabs",
       "storage",
       "scripting",
       "activeTab",


### PR DESCRIPTION
This pull request introduces functionality to include course syllabus content in the search results for the `SearchInCourse` feature, along with a minor adjustment to the extension's permissions. The most significant changes involve adding a new method to fetch syllabus data, updating the course content aggregation logic, and ensuring syllabus links are handled correctly.

### Changes to `SearchInCourse` functionality:

* Added `getSyllabus` method to fetch syllabus content for a course. This method retrieves the syllabus body, validates it, and structures it for inclusion in search results.
* Updated the aggregation logic in `SearchInCourse` to include syllabus data alongside pages, assignments, quizzes, and discussions. The `window.adminToolsCourseContent` object now includes a `syllabus` property.
* Added support for syllabus links in the search results by handling the `syllabus` case in the URL assignment logic.

### Permissions adjustment:

* Removed the `tabs` permission from the `manifest.json` file, likely as part of a cleanup or to reduce the extension's required permissions.