### PR TITLE
fix: mutationObserver fixed

### DIFF
--- a/content/displays/BlueprintSections/displayBlueprintSections.js
+++ b/content/displays/BlueprintSections/displayBlueprintSections.js
@@ -9,15 +9,37 @@ const blueprintAssociations = () => {
   const associatedCourses = document.querySelectorAll(
     'span[dir="ltr"] .bca-associations-table tr[id^="course_"]'
   );
-  associatedCourses.forEach(row => {
-    const courseID = row.id.split('_')[1];
-    const linkSpan = row.querySelector('td span');
+
+  associatedCourses.forEach((row) => {
+    const courseID = row.id.split("_")[1];
+    if (!courseID) return;
+
+    const linkSpan = row.querySelector("td span");
     if (!linkSpan) return;
-    const currentHTML = linkSpan.innerHTML;
-    const expectedLinkHTML = `<a href="/courses/${courseID}" target="_blank">${currentHTML}</a>`;
-    if (!currentHTML.includes(expectedLinkHTML)) {
-      linkSpan.innerHTML = expectedLinkHTML;
+
+    const href = `/courses/${courseID}`;
+
+    // If we already wrapped it, do nothing (idempotent).
+    const existingAnchor = linkSpan.querySelector("a");
+    if (existingAnchor) {
+      if (existingAnchor.getAttribute("href") !== href) {
+        existingAnchor.setAttribute("href", href);
+      }
+      if (existingAnchor.getAttribute("target") !== "_blank") {
+        existingAnchor.setAttribute("target", "_blank");
+      }
+      return;
     }
+
+    // Wrap existing contents (preserves any formatting/nodes inside the span).
+    const a = document.createElement("a");
+    a.href = href;
+    a.target = "_blank";
+
+    while (linkSpan.firstChild) {
+      a.appendChild(linkSpan.firstChild);
+    }
+    linkSpan.appendChild(a);
   });
 };
 


### PR DESCRIPTION
This pull request improves the robustness and idempotency of the logic that wraps associated course names with links in the `blueprintAssociations` function. The new implementation ensures that links are only added if they do not already exist, and preserves any formatting or child nodes inside the span.

Enhancements to link wrapping logic:

* The function now checks if the course ID exists before proceeding, preventing errors when the row ID is malformed.
* Instead of replacing the inner HTML, the code checks for an existing anchor tag and updates its `href` and `target` attributes if necessary, ensuring the operation is idempotent and does not duplicate links.
* When wrapping, the code preserves all existing formatting and child nodes within the span by moving them into the new anchor element, rather than replacing the HTML content.