### PR TITLE
fix: enhance course ID extraction and filter course rows

### DIFF
--- a/content/displays/SectionColumn/displaySectionColumns.js
+++ b/content/displays/SectionColumn/displaySectionColumns.js
@@ -12,7 +12,9 @@ async function buildDetails(row) {
   const courseLink = row.querySelector('a[href*="/courses/"]');
   if (!courseLink) throw new Error("Course link not found in row.");
   const href = courseLink.getAttribute('href');
-  const courseID = href.split('/courses/')[1];
+  const match = href.match(/\/courses\/(\d+)/);
+  const courseID = match?.[1];
+  if (!courseID) throw new Error("Course ID not found in link.");
   const info = { row, courseLink, courseID, sections: [] };
 
   const host = window.location.origin;
@@ -81,7 +83,8 @@ function populateSectionsColumn(courses, columnID) {
 async function main() {
   const tbody = document.querySelector('tbody[data-automation="courses list"]');
   if (!tbody) return;
-  courseRows = Array.from(tbody.querySelectorAll('tr')).slice(1);
+  courseRows = Array.from(tbody.querySelectorAll('tr'))
+    .filter(row => row.querySelector('a[href*="/courses/"]'));
   createColumn('crossListedSections', 'Sections');
   createColumnCells('crossListedSections');
   try {


### PR DESCRIPTION
This pull request improves the robustness and reliability of the section columns display logic by making the extraction of course IDs more reliable and ensuring only valid course rows are processed. The most important changes are:

**Improved Course ID Extraction:**

* Updated the logic in `buildDetails` to extract the course ID using a regular expression, ensuring only numeric IDs are captured and adding an explicit error if the ID is missing.

**More Reliable Row Selection:**

* Modified the row selection in the main function to filter out any rows that do not contain a course link, preventing errors from processing invalid rows.