### PR TITLE
Fix: Improve navbar display logic

### DIFF
--- a/content/displays/ModuleNavbar/displayModuleNavbar.js
+++ b/content/displays/ModuleNavbar/displayModuleNavbar.js
@@ -28,7 +28,7 @@ const createNavbar = () => {
 
   navbar.id = 'navToModule_ext';
   Object.assign(navbar.style, {
-    height: '24px',
+    height: '36px',
     lineHeight: '24px',
     width: `calc(100vw - ${sidebarWidth})`,
     maxWidth: `calc(100vw - ${sidebarWidth})`,
@@ -40,7 +40,8 @@ const createNavbar = () => {
     position: 'fixed',
     bottom: bottomOffset,  // prevents the navbar being covered by the impersonate bar
     left: sidebarWidth,
-    display: 'flex'
+    display: 'flex',
+    alignItems: 'center'
   });
   document.body.appendChild(navbar);
 };

--- a/content/displays/ModuleNavbar/displayModuleNavbar.js
+++ b/content/displays/ModuleNavbar/displayModuleNavbar.js
@@ -17,6 +17,15 @@ const createNavbar = () => {
   if (!sidebar) return;
   const sidebarWidth = window.getComputedStyle(sidebar).getPropertyValue('width');
   const navbar = document.createElement('div');
+
+  const impersonateBar = document.getElementById('fixed_bottom');
+  let bottomOffset = '0';
+  if (impersonateBar) {
+    const barHeight = window.getComputedStyle(impersonateBar).getPropertyValue('height');
+    const height = parseInt(barHeight);
+    bottomOffset = `${height}px`;
+  }
+
   navbar.id = 'navToModule_ext';
   Object.assign(navbar.style, {
     height: '24px',
@@ -29,7 +38,7 @@ const createNavbar = () => {
     padding: '2px',
     color: 'black',
     position: 'fixed',
-    bottom: '0',
+    bottom: bottomOffset,  // prevents the navbar being covered by the impersonate bar
     left: sidebarWidth,
     display: 'flex'
   });

--- a/content/displays/ParentLink/displayParentLink.js
+++ b/content/displays/ParentLink/displayParentLink.js
@@ -9,6 +9,14 @@ function createParentNavbar() {
   const sidebar = document.querySelector('#header');
   if (!sidebar) return;
   const sidebarWidth = window.getComputedStyle(sidebar).getPropertyValue('width');
+
+  const impersonateBar = document.getElementById('fixed_bottom');
+  let bottomOffset = '0';
+  if (impersonateBar) {
+    const barHeight = window.getComputedStyle(impersonateBar).getPropertyValue('height');
+    const height = parseInt(barHeight);
+    bottomOffset = `${height}px`;
+  }
   
   const navbar = document.createElement('div');
   navbar.id = 'navToModule_ext';
@@ -23,7 +31,7 @@ function createParentNavbar() {
     padding: '2px',
     color: 'black',
     position: 'fixed',
-    bottom: '0',
+    bottom: bottomOffset,  // prevents the navbar being covered by the impersonate bar
     left: sidebarWidth,
     display: 'flex'
   });

--- a/content/displays/ParentLink/displayParentLink.js
+++ b/content/displays/ParentLink/displayParentLink.js
@@ -33,7 +33,7 @@ function createParentNavbar() {
     position: 'fixed',
     bottom: bottomOffset,  // prevents the navbar being covered by the impersonate bar
     left: sidebarWidth,
-    display: 'flex'
+    display: 'flex',
   });
   
   document.body.appendChild(navbar);
@@ -70,6 +70,7 @@ async function addBlueprintParent() {
       }
       const blueprintID = blueprintData[0].blueprint_course.id;
       const navbar = document.getElementById('navToModule_ext');
+
       // Create an anchor element for the parent blueprint link
       const anchor = document.createElement('a');
       anchor.href = `${host}/courses/${blueprintID}`;

--- a/content/displays/actAsTeacher/actAsTeacher.js
+++ b/content/displays/actAsTeacher/actAsTeacher.js
@@ -97,10 +97,18 @@
       document.body.appendChild(navbar);
     }
 
+    const impersonateBar = document.getElementById('fixed_bottom');
+    let bottomOffset = '0';
+    if (impersonateBar) {
+      const barHeight = window.getComputedStyle(impersonateBar).getPropertyValue('height');
+      const height = parseInt(barHeight);
+      bottomOffset = `${height}px`;
+    }
+
     // Normalize styles (even if created by another script) so it can't overflow
     Object.assign(navbar.style, {
       position: "fixed",
-      bottom: "0",
+      bottom: bottomOffset,    // prevents the navbar being covered by the impersonate bar
       left: sidebarWidth,
       right: "0",              // key: prevents off-screen width issues
       width: "auto",

--- a/content/displays/actAsTeacher/actAsTeacher.js
+++ b/content/displays/actAsTeacher/actAsTeacher.js
@@ -120,7 +120,7 @@
       color: "black",
       display: "flex",
       alignItems: "center",
-      gap: "4px",              // This also influences the gap between each module link
+      gap: "3px",              // This also influences the gap between each module link
       flexWrap: "wrap",        // allow wrapping instead of overflow
       boxSizing: "border-box"
     });
@@ -151,7 +151,7 @@
       gap: "8px",
       flexWrap: "wrap",
       minWidth: "0",
-      maxWidth: "100%",
+      maxWidth: "100%"
     });
 
     navbar.appendChild(host);

--- a/content/displays/actAsTeacher/actAsTeacher.js
+++ b/content/displays/actAsTeacher/actAsTeacher.js
@@ -120,9 +120,9 @@
       color: "black",
       display: "flex",
       alignItems: "center",
-      gap: "8px",
+      gap: "4px",              // This also influences the gap between each module link
       flexWrap: "wrap",        // allow wrapping instead of overflow
-      boxSizing: "border-box",
+      boxSizing: "border-box"
     });
 
     // Avoid forcing a tiny bar that can't fit controls
@@ -144,12 +144,11 @@
     host.id = "actAsTeacher_ext";
 
     Object.assign(host.style, {
-      marginRight: "auto",     // keep the host on the left
       order: "-1",             // move it to the left within the flex bar
       display: "flex",
       alignItems: "center",
       justifyContent: "flex-start",
-      gap: "6px",
+      gap: "8px",
       flexWrap: "wrap",
       minWidth: "0",
       maxWidth: "100%",


### PR DESCRIPTION
This pull request improves the display logic of module navbar, specifically:

**Navbar stacked above impersonate bar**

- The logic now incorporates the situation where the navbar would be blocked when impersonating other users.
- The navbar is stacked above the pink impersonate bar and remains the same look as before.

**Increased gap between module links and the parent blueprint link**
- in the past, when navigating to course module, the last module link overlapped with the parent blueprint link. It's now resolved by adding more gap between them.
- The module link wrapping logic from the previous update is still in effect.

